### PR TITLE
Group all fluxcd go packages

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -36,7 +36,7 @@
         "go"
       ],
       "matchPackagePrefixes": [
-        "github.com/fluxcd/flux2"
+        "github.com/fluxcd"
       ],
       "prBodyNotes": [
         ":warning: This PR updates an API docstring, so you have to run `make generate` locally."


### PR DESCRIPTION
There is no point in updating individual flux controller packages, as the `github.com/fluxcd/flux2/v2` update will update all other flux packages (see https://github.com/stackitcloud/gardener-extension-shoot-flux/pull/40).