### PR TITLE
Create and update `additionalSecretResources`

### DIFF
--- a/pkg/controller/extension/secrets_test.go
+++ b/pkg/controller/extension/secrets_test.go
@@ -109,7 +109,7 @@ var _ = Describe("ReconcileSecrets", Ordered, func() {
 		Expect(createdSecret.Data).To(HaveKeyWithValue("foo", []byte("extra")))
 	})
 
-	It("should not change an existing secret", func() {
+	It("should change an existing secret", func() {
 		createdSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
 			Name:      "extra",
 			Namespace: "flux-system",
@@ -123,7 +123,7 @@ var _ = Describe("ReconcileSecrets", Ordered, func() {
 		).To(Succeed())
 
 		Expect(shootClient.Get(ctx, client.ObjectKeyFromObject(createdSecret), createdSecret)).To(Succeed())
-		Expect(createdSecret.Data).To(HaveKeyWithValue("foo", []byte("changed")))
+		Expect(createdSecret.Data).To(HaveKeyWithValue("foo", []byte("extra")))
 	})
 
 	It("should respect the target name and clean up the old secret", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:

create and update `additionalSecretResources` instead of creating them only once. This allows pushing secret updates to the shoots without having to setup some external system to manage the secrets (and without having to grant it enough access to update the secrets).

**Special notes for your reviewer**:

Follow-up to https://github.com/stackitcloud/gardener-extension-shoot-flux/pull/81
