### PR TITLE
Do nothing when cluster is hibernated

### DIFF
--- a/pkg/controller/extension/actuator.go
+++ b/pkg/controller/extension/actuator.go
@@ -55,6 +55,11 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ext *extensio
 		return fmt.Errorf("error reading Cluster object: %w", err)
 	}
 
+	if extensionscontroller.IsHibernationEnabled(cluster) {
+		// when hibernation is enabled there is nothing for us to do
+		return nil
+	}
+
 	config, err := a.DecodeProviderConfig(ext.Spec.ProviderConfig)
 	if err != nil {
 		return fmt.Errorf("error decoding providerConfig: %w", err)


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement

**What this PR does / why we need it**:
When a cluster is hibernating, the extension errors, because it tries to connect to the shoot API server.I think the correct thing to do is just do nothing.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
