### PR TITLE
Add `shoot-info` `ConfigMap` with shoot information in flux namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Please find more information regarding the extensibility concepts and a detailed
 - [Gardener Extension for Flux](#gardener-extension-for-flux)
 - [What does this package provide?](#what-does-this-package-provide)
     - [Example use case](#example-use-case)
-    - [shoot-info-envsubst ConfigMap](#shoot-info-envsubst-configmap)
+    - [shoot-info ConfigMap](#shoot-info-configmap)
 - [How to...](#how-to)
     - [Use it as a gardener operator](#use-it-as-a-gardener-operator)
     - [Develop this extension locally](#develop-this-extension-locally)
@@ -40,15 +40,21 @@ In this case, you can make use of this extension and pre-spawn `Shoot`s, which a
 Of course, there is a trade-off, as your pre-spawned shoots will consume some resources (either in terms of money, if running in a public cloud, or in terms of physical resources).
 However, in certain scenarios, this approach will dramatically improve the effectiveness of you CI-workflow.
 
-## `shoot-info-envsubst` `ConfigMap`
+## `shoot-info` `ConfigMap`
 
-If the extension is enabled for a shoot cluster a `ConfigMap` named `shoot-info-envsubst` with information about the shoot
+If the extension is enabled for a shoot cluster a `ConfigMap` named `shoot-info` with information about the shoot
 is created in the flux namespace. The `ConfigMap` can be used in [`substituteFrom`](https://fluxcd.io/flux/components/kustomize/kustomizations/#post-build-variable-substitution)
 in `Kustomizations`. The following information is provided:
 
-- SHOOT_INFO_TECHNICAL_ID
-- SHOOT_INFO_NAME
-- SHOOT_INFO_CLUSTER_IDENTITY
+| key | purpose                                                                                                                | example value                                                        |
+|-----|------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------|
+| SHOOT_INFO_CLUSTER_IDENTITY    | the unique cluster identity which is unique even if the cluster gets re-created.                                       | shoot--someproject--testcluster-5fdf7ca4-5cse-4ab0-a5c4-54faf32f8765 |
+| SHOOT_INFO_NAME | name of the shoot cluster. Be aware that there can be multiple clusters with the same name in different projects.      | testcluster                                                          |
+ | SHOOT_INFO_TECHNICAL_ID | contains name of the shoot cluster and the gardener project it's created in. This is unique per gardener installation. | shoot--someproject--testcluster                                      |
+
+Like the other resources (flux installation) provisioned by this configMap is not deleted when the extension is removed
+from the shoot cluster. This behaviour is intentional to keep the flux installation intact and allow the user to remove
+it in a controlled manner. Please be aware that the `configMap` is no longer updated when the extension is no longer active.
 
 # How to...
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ In this case, you can make use of this extension and pre-spawn `Shoot`s, which a
 Of course, there is a trade-off, as your pre-spawned shoots will consume some resources (either in terms of money, if running in a public cloud, or in terms of physical resources).
 However, in certain scenarios, this approach will dramatically improve the effectiveness of you CI-workflow.
 
-## shoot-info-envsubst configMap
+## `shoot-info-envsubst` `ConfigMap`
 
 If the extension is enabled for a shoot cluster a configMap named `shoot-info-envsubst` with information about the shoot
 is created in the flux namespace. The configMap can be used for [substituteFrom](https://fluxcd.io/flux/components/kustomize/kustomizations/#post-build-variable-substitution)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Please find more information regarding the extensibility concepts and a detailed
 - [Gardener Extension for Flux](#gardener-extension-for-flux)
 - [What does this package provide?](#what-does-this-package-provide)
     - [Example use case](#example-use-case)
+    - [shoot-info-envsubst ConfigMap](#shoot-info-envsubst-configmap)
 - [How to...](#how-to)
     - [Use it as a gardener operator](#use-it-as-a-gardener-operator)
     - [Develop this extension locally](#develop-this-extension-locally)
@@ -43,7 +44,11 @@ However, in certain scenarios, this approach will dramatically improve the effec
 
 If the extension is enabled for a shoot cluster a `ConfigMap` named `shoot-info-envsubst` with information about the shoot
 is created in the flux namespace. The `ConfigMap` can be used in [`substituteFrom`](https://fluxcd.io/flux/components/kustomize/kustomizations/#post-build-variable-substitution)
-in `Kustomizations`.
+in `Kustomizations`. The following information is provided:
+
+- SHOOT_INFO_TECHNICAL_ID
+- SHOOT_INFO_NAME
+- SHOOT_INFO_CLUSTER_IDENTITY
 
 # How to...
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ However, in certain scenarios, this approach will dramatically improve the effec
 
 ## `shoot-info-envsubst` `ConfigMap`
 
-If the extension is enabled for a shoot cluster a configMap named `shoot-info-envsubst` with information about the shoot
-is created in the flux namespace. The configMap can be used for [substituteFrom](https://fluxcd.io/flux/components/kustomize/kustomizations/#post-build-variable-substitution)
-in kustomizations.
+If the extension is enabled for a shoot cluster a `ConfigMap` named `shoot-info-envsubst` with information about the shoot
+is created in the flux namespace. The `ConfigMap` can be used in [`substituteFrom`](https://fluxcd.io/flux/components/kustomize/kustomizations/#post-build-variable-substitution)
+in `Kustomizations`.
 
 # How to...
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ In this case, you can make use of this extension and pre-spawn `Shoot`s, which a
 Of course, there is a trade-off, as your pre-spawned shoots will consume some resources (either in terms of money, if running in a public cloud, or in terms of physical resources).
 However, in certain scenarios, this approach will dramatically improve the effectiveness of you CI-workflow.
 
+## shoot-info-envsubst configMap
+
+If the extension is enabled for a shoot cluster a configMap named `shoot-info-envsubst` with information about the shoot
+is created in the flux namespace. The configMap can be used for [substituteFrom](https://fluxcd.io/flux/components/kustomize/kustomizations/#post-build-variable-substitution)
+in kustomizations.
+
 # How to...
 
 ## Use it as a gardener operator

--- a/pkg/controller/extension/actuator.go
+++ b/pkg/controller/extension/actuator.go
@@ -77,7 +77,7 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ext *extensio
 	}
 
 	if err := ReconcileShootInfoConfigMap(ctx, log, shootClient, config, cluster); err != nil {
-		return fmt.Errorf("error reconciling shootInfoConfigMap: %w", err)
+		return fmt.Errorf("error reconciling ConfigMap %q: %w", shootInfoConfigMapName, err)
 	}
 
 	if IsFluxBootstrapped(ext) {
@@ -172,10 +172,12 @@ func ReconcileShootInfoConfigMap(
 	})
 
 	if err != nil {
-		return fmt.Errorf("failed to create or update %s: %w", shootInfoConfigMapName, err)
+		return fmt.Errorf("failed to create or update ConfigMap %q: %w", client.ObjectKeyFromObject(configMap), err)
 	}
 
-	log.Info("Synced configMap", "Name:", shootInfoConfigMapName, "result", result)
+	if result != controllerutil.OperationResultNone {
+		log.Info("Synced shoot info ConfigMap", "configMap", client.ObjectKeyFromObject(configMap))
+	}
 
 	return err
 }

--- a/pkg/controller/extension/actuator.go
+++ b/pkg/controller/extension/actuator.go
@@ -3,7 +3,6 @@ package extension
 import (
 	"context"
 	"fmt"
-	"github.com/gardener/gardener/pkg/extensions"
 	"time"
 
 	fluxinstall "github.com/fluxcd/flux2/v2/pkg/manifestgen/install"
@@ -17,6 +16,7 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"

--- a/pkg/controller/extension/actuator.go
+++ b/pkg/controller/extension/actuator.go
@@ -76,7 +76,10 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ext *extensio
 		return fmt.Errorf("invalid providerConfig: %w", allErrs.ToAggregate())
 	}
 
-	// Managedresource
+	if err := a.CreateManagedResource(ctx, log, config, cluster); err != nil {
+		// TBD
+		return fmt.Errorf("error creating or updating managed resource: %w", err)
+	}
 
 	_, shootClient, err := util.NewClientForShoot(ctx, a.client, ext.Namespace, client.Options{Scheme: a.client.Scheme()}, extensionsconfig.RESTOptions{})
 	if err != nil {

--- a/pkg/controller/extension/actuator.go
+++ b/pkg/controller/extension/actuator.go
@@ -36,10 +36,6 @@ import (
 	"github.com/stackitcloud/gardener-extension-shoot-flux/pkg/apis/flux/v1alpha1/validation"
 )
 
-const (
-	shootInfoConfigMapName = "shoot-info-envsubst"
-)
-
 type actuator struct {
 	client  client.Client
 	decoder runtime.Decoder
@@ -80,7 +76,7 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ext *extensio
 		return fmt.Errorf("error creating shoot client: %w", err)
 	}
 
-	if err := reconcileShootInfoConfigMap(ctx, log, shootClient, config, cluster); err != nil {
+	if err := ReconcileShootInfoConfigMap(ctx, log, shootClient, config, cluster); err != nil {
 		return fmt.Errorf("error reconciling shootInfoConfigMap: %w", err)
 	}
 
@@ -148,7 +144,7 @@ func (a *actuator) Restore(context.Context, logr.Logger, *extensionsv1alpha1.Ext
 // ReconcileShootInfoConfigMap creates or updates a ConfigMap in the specified Flux namespace in the shoot cluster.
 // The ConfigMap contains information about the Shoot cluster, such as its technical ID which can be used for
 // substitutions in flux kustomizations or helmreleases.
-func reconcileShootInfoConfigMap(
+func ReconcileShootInfoConfigMap(
 	ctx context.Context,
 	log logr.Logger,
 	shootClient client.Client,
@@ -168,7 +164,10 @@ func reconcileShootInfoConfigMap(
 		}
 		configMap.Data = map[string]string{
 			"SHOOT_TECHNICAL_ID": cluster.Shoot.Status.TechnicalID,
-			// TBD
+			"SHOOT_NAME":         cluster.Shoot.Name,
+			"CLUSTER_NAME":       cluster.Shoot.Name,
+			"SEED_NAME":          *cluster.Shoot.Status.SeedName,
+			"DOMAIN":             *cluster.Shoot.Spec.DNS.Domain,
 		}
 		return nil
 	})

--- a/pkg/controller/extension/actuator.go
+++ b/pkg/controller/extension/actuator.go
@@ -178,7 +178,7 @@ func ReconcileShootInfoConfigMap(
 		log.Info("Synced shoot info ConfigMap", "configMap", client.ObjectKeyFromObject(configMap))
 	}
 
-	return err
+	return nil
 }
 
 // DecodeProviderConfig decodes the given providerConfig and performs API defaulting. If the providerConfig is empty,

--- a/pkg/controller/extension/actuator.go
+++ b/pkg/controller/extension/actuator.go
@@ -166,7 +166,6 @@ func ReconcileShootInfoConfigMap(
 			"SHOOT_TECHNICAL_ID": cluster.Shoot.Status.TechnicalID,
 			"SHOOT_NAME":         cluster.Shoot.Name,
 			"CLUSTER_NAME":       cluster.Shoot.Name,
-			"SEED_NAME":          *cluster.Shoot.Status.SeedName,
 			"DOMAIN":             *cluster.Shoot.Spec.DNS.Domain,
 		}
 		return nil

--- a/pkg/controller/extension/actuator.go
+++ b/pkg/controller/extension/actuator.go
@@ -163,9 +163,9 @@ func ReconcileShootInfoConfigMap(
 			managedByLabelKey: managedByLabelValue,
 		}
 		configMap.Data = map[string]string{
-			"SHOOT_INFO_TECHNICAL_ID":     cluster.Shoot.Status.TechnicalID,
-			"SHOOT_INFO_NAME":             cluster.Shoot.Name,
 			"SHOOT_INFO_CLUSTER_IDENTITY": *cluster.Shoot.Status.ClusterIdentity,
+			"SHOOT_INFO_NAME":             cluster.Shoot.Name,
+			"SHOOT_INFO_TECHNICAL_ID":     cluster.Shoot.Status.TechnicalID,
 		}
 		return nil
 	})

--- a/pkg/controller/extension/actuator.go
+++ b/pkg/controller/extension/actuator.go
@@ -163,10 +163,9 @@ func ReconcileShootInfoConfigMap(
 			managedByLabelKey: managedByLabelValue,
 		}
 		configMap.Data = map[string]string{
-			"SHOOT_TECHNICAL_ID": cluster.Shoot.Status.TechnicalID,
-			"SHOOT_NAME":         cluster.Shoot.Name,
-			"CLUSTER_NAME":       cluster.Shoot.Name,
-			"DOMAIN":             *cluster.Shoot.Spec.DNS.Domain,
+			"SHOOT_INFO_TECHNICAL_ID":     cluster.Shoot.Status.TechnicalID,
+			"SHOOT_INFO_NAME":             cluster.Shoot.Name,
+			"SHOOT_INFO_CLUSTER_IDENTITY": *cluster.Shoot.Status.ClusterIdentity,
 		}
 		return nil
 	})

--- a/pkg/controller/extension/actuator_test.go
+++ b/pkg/controller/extension/actuator_test.go
@@ -286,7 +286,7 @@ var _ = Describe("ReconcileShootInfoConfigMap", func() {
 
 		Expect(ReconcileShootInfoConfigMap(ctx, log, shootClient, config, cluster)).To(Succeed())
 
-		Expect(shootClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap))
+		Expect(shootClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
 		Expect(len(configMap.Data)).To(Equal(3))
 		Expect(configMap.Data).To(Equal(map[string]string{
 			"SHOOT_INFO_CLUSTER_IDENTITY": clusterIdentity,

--- a/pkg/controller/extension/actuator_test.go
+++ b/pkg/controller/extension/actuator_test.go
@@ -258,7 +258,7 @@ var _ = Describe("ReconcileShootInfoConfigMap", func() {
 
 	It("should apply successfully and contain expected keys", func() {
 		shootName := "test-shoot"
-		technicalID := fmt.Sprintf("shoot--asdf-test-%s", shootName)
+		technicalID := fmt.Sprintf("shoot--asdf-test--%s", shootName)
 		clusterIdentity := "magic-cluster-identity"
 		shootClient = newShootClient()
 		config = &fluxv1alpha1.FluxConfig{

--- a/pkg/controller/extension/actuator_test.go
+++ b/pkg/controller/extension/actuator_test.go
@@ -3,8 +3,6 @@ package extension
 import (
 	"context"
 	"fmt"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"github.com/gardener/gardener/pkg/extensions"
 	"io"
 	"os"
 	"path/filepath"
@@ -13,7 +11,9 @@ import (
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 	fluxmeta "github.com/fluxcd/pkg/apis/meta"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/extensions"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"

--- a/pkg/controller/extension/constants.go
+++ b/pkg/controller/extension/constants.go
@@ -1,0 +1,9 @@
+package extension
+
+import fluxv1alpha1 "github.com/stackitcloud/gardener-extension-shoot-flux/pkg/apis/flux/v1alpha1"
+
+const (
+	managedByLabelKey      = "app.kubernetes.io/managed-by"
+	managedByLabelValue    = "gardener-extension-" + fluxv1alpha1.ExtensionType
+	shootInfoConfigMapName = "shoot-info-envsubst"
+)

--- a/pkg/controller/extension/constants.go
+++ b/pkg/controller/extension/constants.go
@@ -5,5 +5,5 @@ import fluxv1alpha1 "github.com/stackitcloud/gardener-extension-shoot-flux/pkg/a
 const (
 	managedByLabelKey      = "app.kubernetes.io/managed-by"
 	managedByLabelValue    = "gardener-extension-" + fluxv1alpha1.ExtensionType
-	shootInfoConfigMapName = "shoot-info-envsubst"
+	shootInfoConfigMapName = "shoot-info"
 )

--- a/pkg/controller/extension/secrets.go
+++ b/pkg/controller/extension/secrets.go
@@ -19,11 +19,6 @@ import (
 	fluxv1alpha1 "github.com/stackitcloud/gardener-extension-shoot-flux/pkg/apis/flux/v1alpha1"
 )
 
-const (
-	managedByLabelKey   = "app.kubernetes.io/managed-by"
-	managedByLabelValue = "gardener-extension-" + fluxv1alpha1.ExtensionType
-)
-
 // ReconcileSecrets copies all secrets referenced in the extension (additionalSecretResources or
 // source.SecretResourceName), and deletes all secrets that are no longer referenced.
 // We cannot use gardener resource manager here, because we want to work in the namespace


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:

When deploying flux it's likely that we need some information about the shoot cluster in kustomizations. By adding a configmap containing this information in the flux namespace we can directly access this information from kustomizations. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
add shoot-info-envsubst configMap in flux namespace
```
