### PR TITLE
Fix `shoot-info` `ConfigMap` creation when bootstrapping flux

### DIFF
--- a/pkg/controller/extension/actuator.go
+++ b/pkg/controller/extension/actuator.go
@@ -105,6 +105,11 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ext *extensio
 		}
 	}
 
+	// configMap might be necessary for the kustomization to get ready
+	if err := ReconcileShootInfoConfigMap(ctx, log, shootClient, config, cluster); err != nil {
+		return fmt.Errorf("error reconciling ConfigMap %q: %w", shootInfoConfigMapName, err)
+	}
+
 	if config.Kustomization != nil {
 		if err := BootstrapKustomization(ctx, log, shootClient, config.Kustomization); err != nil {
 			return fmt.Errorf("error bootstrappping Flux Kustomization: %w", err)

--- a/pkg/controller/extension/actuator.go
+++ b/pkg/controller/extension/actuator.go
@@ -76,15 +76,15 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ext *extensio
 		return fmt.Errorf("error creating shoot client: %w", err)
 	}
 
-	if err := ReconcileShootInfoConfigMap(ctx, log, shootClient, config, cluster); err != nil {
-		return fmt.Errorf("error reconciling ConfigMap %q: %w", shootInfoConfigMapName, err)
-	}
-
 	if IsFluxBootstrapped(ext) {
 		log.V(1).Info("Flux installation has been bootstrapped already, will only reconcile secrets")
 
 		if err := ReconcileSecrets(ctx, log, a.client, shootClient, ext.Namespace, config, cluster.Shoot.Spec.Resources); err != nil {
 			return fmt.Errorf("error reconciling secrets: %w", err)
+		}
+
+		if err := ReconcileShootInfoConfigMap(ctx, log, shootClient, config, cluster); err != nil {
+			return fmt.Errorf("error reconciling ConfigMap %q: %w", shootInfoConfigMapName, err)
 		}
 
 		return nil


### PR DESCRIPTION
**How to categorize this PR?**
/area ops-productivity
/kind bug

**What this PR does / why we need it**:

When bootstrapping completely new seeds/shoots, the extension will fail as the namespace `flux-system` (or whatever is configured) does not exists yet. This PR addresses that by running `ReconcileShootInfoConfigMap` only after flux has been fully bootstrapped.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```bugfix operator
Fixed a bug in the Reconcile loop when seed does not have the configured namespace for flux yet.
```
