### PR TITLE
Publish Helm chart as OCI artifact

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -30,4 +30,4 @@ jobs:
       with:
         go-version-file: go.mod
     - run: make init
-    - run: make images PUSH=true
+    - run: make artifacts PUSH=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+artifacts
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-artifacts
+artifacts/
+images.txt
 
 # Binaries for programs and plugins
 *.exe

--- a/Makefile
+++ b/Makefile
@@ -47,16 +47,19 @@ debug:
 #################################################################
 
 PUSH ?= false
+OUTPUT_IMAGES_PATH ?= "images.txt"
+
 images: export KO_DOCKER_REPO = $(REPO)
 images: export LD_FLAGS := $(LD_FLAGS)
 
 .PHONY: images
 images: $(KO)
-	KO_DOCKER_REPO=$(REPO) $(KO) build --sbom none -t $(TAG) --bare --platform linux/amd64,linux/arm64 --push=$(PUSH) ./cmd/gardener-extension-shoot-flux
+	KO_DOCKER_REPO=$(REPO) $(KO) build --sbom none -t $(TAG) --bare --platform linux/amd64,linux/arm64 --push=$(PUSH) ./cmd/gardener-extension-shoot-flux \
+	  | tee $(OUTPUT_IMAGES_PATH)
 
 .PHONY: artifacts-only
 artifacts-only: $(YQ) $(HELM) ## Builds helm charts (`charts/`)
-	hack/push-artifacts.sh $(REPO)/$(EXTENSION_PREFIX)-$(NAME):$(TAG)
+	hack/push-artifacts.sh $(OUTPUT_IMAGES_PATH)
 
 .PHONY: artifacts
 artifacts: images artifacts-only ## Builds all artifacts.

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,13 @@ images: export LD_FLAGS := $(LD_FLAGS)
 images: $(KO)
 	KO_DOCKER_REPO=$(REPO) $(KO) build --sbom none -t $(TAG) --bare --platform linux/amd64,linux/arm64 --push=$(PUSH) ./cmd/gardener-extension-shoot-flux
 
+.PHONY: artifacts-only
+artifacts-only: $(YQ) $(HELM) ## Builds helm charts (`charts/`)
+	hack/push-artifacts.sh $(REPO)/$(EXTENSION_PREFIX)-$(NAME):$(TAG)
+
+.PHONY: artifacts
+artifacts: images artifacts-only ## Builds all artifacts.
+
 #####################################################################
 # Rules for verification, formatting, linting, testing and cleaning #
 #####################################################################

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ debug:
 #################################################################
 
 PUSH ?= false
-OUTPUT_IMAGES_PATH ?= "images.txt"
+OUTPUT_IMAGES_PATH = "images.txt"
 
 images: export KO_DOCKER_REPO = $(REPO)
 images: export LD_FLAGS := $(LD_FLAGS)

--- a/example/operator-extension.yaml
+++ b/example/operator-extension.yaml
@@ -1,0 +1,16 @@
+apiVersion: operator.gardener.cloud/v1alpha1
+kind: Extension
+metadata:
+  name: shoot-flux
+  annotations:
+    security.gardener.cloud/pod-security-enforce: privileged
+spec:
+  resources:
+  - kind: Extension
+    type: shoot-flux
+  deployment:
+    extension:
+      helm:
+        ociRepository:
+          repository: ghcr.io/stackitcloud/charts/gardener-extension-shoot-flux
+          tag: latest

--- a/hack/push-artifacts.sh
+++ b/hack/push-artifacts.sh
@@ -10,7 +10,7 @@ rm -rf "$helm_artifacts"
 mkdir -p "$helm_artifacts"
 
 function image_registry() {
-  echo "$1" | cut -d '/' -f 1
+  echo "$1" | cut -d '/' -f -2
 }
 
 function image_repo() {

--- a/hack/push-artifacts.sh
+++ b/hack/push-artifacts.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+chart_name=gardener-extension-shoot-flux
+helm_artifacts=artifacts/charts
+rm -rf "$helm_artifacts"
+mkdir -p "$helm_artifacts"
+
+function image_registry() {
+  echo "$1" | cut -d '/' -f 1
+}
+
+function image_repo() {
+  echo "$1" | cut -d ':' -f 1
+}
+
+function image_tag() {
+  echo "$1" | cut -d ':' -f 2-
+}
+
+## HELM
+cp -r charts/${chart_name} "$helm_artifacts"
+yq -i "\
+  ( .image.repository = \"$(image_repo "$1")\" ) | \
+  ( .image.tag = \"$(image_tag "$1")\" )\
+" "$helm_artifacts/${chart_name}/values.yaml"
+
+# push to registry
+if [ "$PUSH" != "true" ] ; then
+  echo "Skip pushing artifacts because PUSH is not set to 'true'"
+  exit 0
+fi
+
+helm package "$helm_artifacts/${chart_name}" --version "$(image_tag "$1")" -d "$helm_artifacts" > /dev/null 2>&1
+helm push "$helm_artifacts/${chart_name}-"* "oci://$(image_registry "$1")/charts"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR adapts the existing `Images` Github action to also push the extension Helm chart as OCI artifact.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Extension Helm chart is now published as OCI artifact.
```
