### PR TITLE
Replace deprecated `Shoot.spec.cloudProfileName`

### DIFF
--- a/example/shoot.yaml
+++ b/example/shoot.yaml
@@ -50,7 +50,8 @@ spec:
   #     kind: Secret
   #     name: project-vault-secret
 
-  cloudProfileName: local
+  cloudProfile:
+    name: local
   secretBindingName: local # dummy, doesn't contain any credentials
   region: local
   networking:


### PR DESCRIPTION
<!--
Please select the kind of this pull request, e.g.:
/kind enhancement

Categorize your change, e.g.:
/label RRWG change, Emergency change 
Normal changes do not require a label.  
More info here https://itdoc.schwarz/display/STACKIT/Change+process

Tide will not merge your PR, if it is missing a `kind/*` label.
"/kind" identifiers:    api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:

Switch from `Shoot.spec.cloudProfileName` to `Shoot.spec.cloudProfile.name`.

See https://github.com/gardener/gardener/pull/11816

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

/cc @stackitcloud/ske-gardener 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
