### PR TITLE
Update docstring when renovate updates flux

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,6 +39,18 @@
       datasourceTemplate: 'go',
     },
     {
+      description: 'Update the default Flux version in the generated API reference docs.',
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^hack/api-reference/api\\.md$/',
+      ],
+      matchStrings: [
+        'Defaults to "(?<currentValue>v[0-9.]+)"',
+      ],
+      depNameTemplate: 'github.com/fluxcd/flux2/v2',
+      datasourceTemplate: 'go',
+    },
+    {
       description: 'Update `_VERSION` and `_version` variables in Makefiles and scripts. Inspired by `regexManagers:dockerfileVersions` preset.',
       customType: 'regex',
       managerFilePatterns: [
@@ -64,9 +76,6 @@
       groupName: 'fluxcd',
       matchDatasources: [
         'go',
-      ],
-      prBodyNotes: [
-        ':warning: This PR updates an API docstring, so you have to run `make generate` locally.',
       ],
       matchPackageNames: [
         'github.com/fluxcd{/,}**',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,32 +19,20 @@
   commitMessagePrefix: '🤖 ',
   customManagers: [
     {
+      description: 'Update the default Flux version in code, examples, and generated API reference docs.',
       customType: 'regex',
       managerFilePatterns: [
         '/^pkg/apis/flux/.*\\.go$/',
         '/^example/shoot\\.yaml/',
+        '/^hack/api-reference/api\\.md$/',
       ],
       matchStrings: [
         'defaultFluxVersion = "(?<currentValue>v[0-9.]+)"',
         // this matches any comment block that has 'renovate:flux-version', then
         // any number of empty or comment lines, and then a substring that
-        // matches e.g. "Defaults to "v1.0.0".
-        'renovate:flux-version\\n(?:\\s*(?:\\/\\/).*\n)*.*Defaults to "(?<currentValue>v[0-9.]+)"',
-        // this matches any comment block that has 'renovate:flux-version', then
-        // any number of empty or comment lines, and then a substring that
         // matches e.g. "version: v1.0.0".
         'renovate:flux-version\\n(?:\\s*(?:#).*\n)*.*version: (?<currentValue>v[0-9.]+)\\s',
-      ],
-      depNameTemplate: 'github.com/fluxcd/flux2/v2',
-      datasourceTemplate: 'go',
-    },
-    {
-      description: 'Update the default Flux version in the generated API reference docs.',
-      customType: 'regex',
-      managerFilePatterns: [
-        '/^hack/api-reference/api\\.md$/',
-      ],
-      matchStrings: [
+        // Matches any string that matches e.g. "Defaults to "v1.0.0".
         'Defaults to "(?<currentValue>v[0-9.]+)"',
       ],
       depNameTemplate: 'github.com/fluxcd/flux2/v2',

--- a/pkg/apis/flux/v1alpha1/types.go
+++ b/pkg/apis/flux/v1alpha1/types.go
@@ -43,7 +43,6 @@ type AdditionalResource struct {
 
 // FluxInstallation configures the Flux installation in the Shoot cluster.
 type FluxInstallation struct {
-	// renovate:flux-version
 	// renovate updates the doc string. See renovate config for more details
 
 	// Version specifies the Flux version that should be installed.


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement

**What this PR does / why we need it**:
Adds a new regex manager for the api reference doc, that contains the flux version. By matching the `depName` it should be presented in the same PR so we no longer need to run stuff manually in PRs like https://github.com/stackitcloud/gardener-extension-shoot-flux/pull/271

**Which issue(s) this PR fixes**:
Fixes manual steps in update PRs like https://github.com/stackitcloud/gardener-extension-shoot-flux/pull/271

**Special notes for your reviewer**:
/cc @timebertt 
