### PR TITLE
chore: Update go version to 1.26.5 (ko needs >=1.26.3)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stackitcloud/gardener-extension-shoot-flux
 
-go 1.26.0
+go 1.26.5
 
 require (
 	github.com/elastic/crd-ref-docs v0.3.0


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind task

**What this PR does / why we need it**:
Update the go dependency in `go.mod` from `1.26.0` to `1.26.5`, as currently the images push pipeline fails with
`go: github.com/google/ko@v0.19.1: github.com/google/ko@v0.19.1 requires go >= 1.26.3 (running go 1.26.0; GOTOOLCHAIN=local)`.

**Which issue(s) this PR fixes**:
x

**Special notes for your reviewer**:

/cc @stackitcloud/ske-gardener 